### PR TITLE
Fix Elixir 1.4 warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ defmodule LoggerJSONFileBackend.Mixfile do
      version: "0.1.4",
      description: "Logger backend that write a json map per line to a file",
      elixir: "~> 1.2",
-     package: package,
-     deps: deps]
+     package: package(),
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
- Add parens to zero-arity functions