### PR TITLE
Fix gen_event callbacks

### DIFF
--- a/lib/logger_json_file_backend.ex
+++ b/lib/logger_json_file_backend.ex
@@ -4,18 +4,22 @@ defmodule LoggerJSONFileBackend do
   @macro_env_fields Map.keys(%Macro.Env{})
   @formatter if Version.compare(System.version(), "1.6.0") == :lt, do: Logger.Utils, else: Logger.Formatter
 
+  @impl :gen_event
   def init({__MODULE__, name}) do
     {:ok, configure(name, [])}
   end
 
+  @impl :gen_event
   def handle_call({:configure, opts}, %{name: name} = state) do
     {:ok, :ok, configure(name, opts, state)}
   end
 
+  @impl :gen_event
   def handle_call(:path, %{path: path} = state) do
     {:ok, {:ok, path}, state}
   end
 
+  @impl :gen_event
   def handle_event({level, _gl, {Logger, msg, ts, md}}, %{level: min_level}=state) do
     if is_nil(min_level) or Logger.compare_levels(level, min_level) != :lt do
       log_event(level, msg, ts, md, state)
@@ -24,7 +28,23 @@ defmodule LoggerJSONFileBackend do
     end
   end
 
+  @impl :gen_event
   def handle_event(:flush, state) do
+    {:ok, state}
+  end
+
+  @impl :gen_event
+  def handle_info(_msg, state) do
+    {:ok, state}
+  end
+
+  @impl :gen_event
+  def terminate(_reason, _state) do
+    :ok
+  end
+
+  @impl :gen_event
+  def code_change(_old, state, _extra) do
     {:ok, state}
   end
 


### PR DESCRIPTION
Implement gen_event callback functions.

- `handle_info/2`
- `terminate/2`
- `code_change/3`

It makes below error fix.
```
18:24:19.196 [error] :gen_event handler {LoggerJSONFileBackend, :debug} installed at Logger
** (exit) an exception was raised:
    ** (UndefinedFunctionError) function LoggerJSONFileBackend.handle_info/2 is undefined or private. Did you mean one of:

      * handle_event/2

        (logger_json_file_backend) LoggerJSONFileBackend.handle_info({:io_reply, #Reference<0.0.4.15910>, :ok}, %{inode: 0, io_device: #PID<0.1924.0>, json_encoder: Poison, level: :debug, metadata: [:requests, :responses, :user_id, :request_id, :resources, :tag, :stats, :game_id], name: :debug, path: "log/app.log", triming: true, uuid: false})
        (stdlib) gen_event.erl:533: :gen_event.server_update/4
        (stdlib) gen_event.erl:515: :gen_event.server_notify/4
        (stdlib) gen_event.erl:303: :gen_event.handle_msg/5
        (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```